### PR TITLE
ASM-4727 SQL Server 2012 App deployment intermittently fails due to puppet exec timeout

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -67,7 +67,7 @@ class mssql2012 (
     path      => $media,
     logoutput => true,
     creates   => $instancedir,
-    timeout   => 1200,
+    timeout   => 3000,
     require   => [ File['C:\sql2012install.ini'],
                    Dism['NetFx3'] ],
   }


### PR DESCRIPTION
Updated the timeout to 3000 seconds from 1200 seconds. Validated the timeout with 4 VMs having simultaneous installation of SQL Servers from the same repository