### PR TITLE
ASM-4967 "Instance directory" in SQL application component needs to be updated

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -21,7 +21,7 @@ class mssql2012 (
   $rssvcpassword  = 'Sql!Rs#2012demo',
   $sqlsvcaccount  = 'SQLSVC',
   $sqlsvcpassword = 'Sql!#2012demo',
-  $instancedir    = 'C:\Program Files\Microsoft SQL Server\\',
+  $instancedir    = 'C:\Program Files\Microsoft SQL Server',
   $ascollation    = 'Latin1_General_CI_AS',
   $sqlcollation   = 'SQL_Latin1_General_CP1_CI_AS',
   $admin          = 'Administrator',


### PR DESCRIPTION
Trailing backward slash in the default parameter leading to the failure of SQL 2012 installation. Removed the parameter from the default values of the manifest file.