### PR TITLE
ASM-7756 Prevent cleartext MSSQL password exposure

### DIFF
--- a/manifests/init.pp
+++ b/manifests/init.pp
@@ -9,66 +9,69 @@
 class mssql2012 (
 # See http://msdn.microsoft.com/en-us/library/ms144259.aspx
   # Media is required to install
-  $media          = '\\dellasm\razor\SQLServer2012',
-  $instancename   = 'MSSQLSERVER',
-  $features       = 'SQLENGINE,CONN,SSMS,ADV_SSMS',
-  $sapwd          = 'Sql!@as#2012demo',
-  $agtsvcaccount  = 'SQLAGTSVC',
-  $agtsvcpassword = 'Sql!@gt#2012demo',
-  $assvcaccount   = 'SQLASSVC',
-  $assvcpassword  = 'Sql!@s#2012demo',
-  $rssvcaccount   = 'SQLRSSVC',
-  $rssvcpassword  = 'Sql!Rs#2012demo',
-  $sqlsvcaccount  = 'SQLSVC',
-  $sqlsvcpassword = 'Sql!#2012demo',
-  $instancedir    = 'C:\Program Files\Microsoft SQL Server',
-  $ascollation    = 'Latin1_General_CI_AS',
-  $sqlcollation   = 'SQL_Latin1_General_CP1_CI_AS',
-  $admin          = 'Administrator',
-  $netfxsource    = '\\dellasm\razor\windows_install\sources\sxs'
+  $media          = "\\dellasm\razor\SQLServer2012",
+  $instancename   = "MSSQLSERVER",
+  $features       = "SQLENGINE,CONN,SSMS,ADV_SSMS",
+  $sapwd          = "Sql!@as#2012demo",
+  $agtsvcaccount  = "SQLAGTSVC",
+  $agtsvcpassword = "Sql!@gt#2012demo",
+  $assvcaccount   = "SQLASSVC",
+  $assvcpassword  = "Sql!@s#2012demo",
+  $rssvcaccount   = "SQLRSSVC",
+  $rssvcpassword  = "Sql!Rs#2012demo",
+  $sqlsvcaccount  = "SQLSVC",
+  $sqlsvcpassword = "Sql!#2012demo",
+  $instancedir    = "C:\Program Files\Microsoft SQL Server",
+  $ascollation    = "Latin1_General_CI_AS",
+  $sqlcollation   = "SQL_Latin1_General_CP1_CI_AS",
+  $admin          = "Administrator",
+  $netfxsource    = "\\dellasm\razor\windows_install\sources\sxs"
 )  {
 
   User {
     ensure   => present,
-    before => Exec['install_mssql2012'],
+    before => Exec["install_mssql_2012"],
   }
 
-  user { 'SQLAGTSVC':
-    comment  => 'SQL 2012 Agent Service.',
+  user { "SQLAGTSVC":
+    comment  => "SQL 2012 Agent Service.",
     password => $agtsvcpassword,
+    provider => "asm_decrypt_token",
   }
-  user { 'SQLASSVC':
-    comment  => 'SQL 2012 Analysis Service.',
+  user { "SQLASSVC":
+    comment  => "SQL 2012 Analysis Service.",
     password => $assvcpassword,
+    provider => "asm_decrypt_token",
   }
-  user { 'SQLRSSVC':
-    comment  => 'SQL 2012 Report Service.',
+  user { "SQLRSSVC":
+    comment  => "SQL 2012 Report Service.",
     password => $rssvcpassword,
+    provider => "asm_decrypt_token",
   }
-  user { 'SQLSVC':
-    comment  => 'SQL 2012 Service.',
-    groups   => 'Administrators',
+  user { "SQLSVC":
+    comment  => "SQL 2012 Service.",
+    groups   => "Administrators",
     password => $sqlsvcpassword,
+    provider => "asm_decrypt_token",
   }
 
-  file { 'C:\sql2012install.ini':
-    content => template('mssql2012/config.ini.erb'),
+  file { "C:\sql2012install.ini":
+    content => template("mssql2012/config.ini.erb"),
   }
 
-  dism { 'NetFx3':
+  dism { "NetFx3":
     ensure           => present,
     source           => $netfxsource,
     all_dependencies => 1
   }
 
-  exec { 'install_mssql2012':
-    command   => "${media}\\setup.exe /Action=Install /IACCEPTSQLSERVERLICENSETERMS /Q /HIDECONSOLE /CONFIGURATIONFILE=C:\\sql2012install.ini /SAPWD=\"${sapwd}\" /SQLSVCPASSWORD=\"${sqlsvcpassword}\" /AGTSVCPASSWORD=\"${agtsvcpassword}\" /ASSVCPASSWORD=\"${assvcpassword}\" /RSSVCPASSWORD=\"${rssvcpassword}\"",
-    cwd       => $media,
-    path      => $media,
+  exec { "install_mssql_2012":
+    command   => template("mssql2012/install_mssql_2012.ps1.erb"),
     logoutput => true,
     creates   => $instancedir,
     timeout   => 3000,
-    require   => [ File['C:\sql2012install.ini'],
-                   Dism['NetFx3'] ],
+    require   => [ File["C:\sql2012install.ini"],
+                       Dism["NetFx3"] ],
+    provider  => powershell,
   }
 }

--- a/templates/install_mssql_2012.ps1.erb
+++ b/templates/install_mssql_2012.ps1.erb
@@ -1,0 +1,28 @@
+# Powershell script template for installing MSSQL 2012
+
+$sa_token     = '<%= @sapwd.gsub("'", "''") %>'
+$sqlsvc_token = '<%= @sqlsvcpassword.gsub("'", "''") %>'
+$agtsvc_token = '<%= @agtsvcpassword.gsub("'", "''") %>'
+$assvc_token  = '<%= @assvcpassword.gsub("'", "''") %>'
+$rssvc_token  = '<%= @rssvcpassword.gsub("'", "''") %>'
+$media        = '<%= @media.gsub("'", "''") %>'
+
+# Get our cert name for use in HTTP GET to fetch decrypted password
+$cert_name = &"puppet.bat" config print node_name_value
+
+Function GetPass( [String]$password ) {
+  $pass = $password
+  if ( $password -match "ASMTOKEN") {
+    $uri = "http://dellasm:8080/asm/secret/tokencred/${cert_name}?token_key=${password}"
+    $pass = Invoke-RestMethod -URI $uri -Method Get
+  }
+  return $pass
+}
+
+$sapwd          = GetPass($sa_token)
+$sqlsvcpassword = GetPass($sqlsvc_token)
+$agtsvcpassword = GetPass($agtsvc_token)
+$assvcpassword  = GetPass($assvc_token)
+$rssvcpassword  = GetPass($rssvc_token)
+
+&"${media}\setup.exe" /Action=Install /IACCEPTSQLSERVERLICENSETERMS /Q /HIDECONSOLE /CONFIGURATIONFILE=C:\\sql2012install.ini /SAPWD=$sapwd /SQLSVCPASSWORD=$sqlsvcpassword /AGTSVCPASSWORD=$agtsvcpassword /ASSVCPASSWORD=$assvcpassword /RSSVCPASSWORD=$rssvcpassword


### PR DESCRIPTION
Previously, during MS SQL installation, the nodedata .yaml file for the
target server was being populated with cleartext passwords for several
required MS SQL accounts. This change fixes that by populating the
nodedata.yaml file with password tokens created using existing code
for the Windows domain password. These tokens are then fetched and
and decrypted the actual MS SQL installation.

The structure of the deployments/serverdata/agent.data file had to
be changed to accommodate multiple tokens. There should be no upgrade
issue as this file is rewritten with each deployment/retry with new
token data. Any existing token data will simply be ignored. That file
will periodically be deleted either by the ASM::Processor::CleanupJobs
code or when the last expired token is fetched.

Also ensured that passwords don't appear in the various Windows logs
generated during MS SQL installation.